### PR TITLE
fixed redux-logger fail issue in the example

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "express": "^4.14.0",
     "lodash": "^4.17.2",
     "redux-bootstrap": "^1.1.0",
-    "redux-logger": "^2.6.1",
+    "redux-logger": "^2.10.2",
     "redux-thunk": "^2.0.1",
     "node-sass": "^4.0.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",
     "@types/express": "^4.0.34",
-    "@types/history": "^2.0.45",
+    "@types/history": "^3.2.0",
     "@types/lodash": "^4.14.43",
     "@types/mocha": "^2.2.33",
     "@types/node": "^7.0.0",
@@ -45,10 +45,10 @@
     "@types/react": "^15.0.0",
     "@types/react-dom": "^0.14.19",
     "@types/react-redux": "^4.4.35",
-    "@types/react-router": "^4.0.0",
+    "@types/react-router": "^3.0.0",
     "@types/react-router-redux": "^4.0.35",
     "@types/redux-immutable": "^3.0.31",
-    "@types/redux-logger": "^2.6.32",
+    "@types/redux-logger": "^2.10.0",
     "@types/sinon": "^1.16.32",
     "awesome-typescript-loader": "^3.0.8",
     "chai": "^3.5.0",
@@ -71,7 +71,7 @@
     "tslint-loader": "~3.4.0",
     "typescript": "^2.1.4",
     "webpack": "^1.14.0",
-    "webpack-dev-server": "^2.3.0",
+    "webpack-dev-server": "^1.16.3",
     "webpack-visualizer-plugin": "^0.1.5"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import thunk from "redux-thunk";
 import { bootstrap } from "redux-bootstrap";
-import * as createLogger from "redux-logger";
+// import createLogger from "redux-logger";
+const createLogger = require('redux-logger')
 import { throttle } from "lodash";
 import routes from "./config/routes";
 import reposReducer from "./reducers/repos_reducer";
@@ -13,7 +14,7 @@ declare var __PRELOADED_STATE__: any;
 let middleware: any[] = [thunk];
 
 if (process.env.NODE_ENV !== "production") {
-    middleware.push(createLogger());
+    middleware.push(createLogger({level: 'log'}));
 }
 
 let preloadedState: any = null;


### PR DESCRIPTION

Fixed the example after updating redux-logger. However there is another known issue with redux-logger which avoids using `import` due to [bug](https://github.com/evgenyrodionov/redux-logger/issues/208)